### PR TITLE
Clear Contents of PASTE sheet before push

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -133,6 +133,8 @@ function BitMEXGetHistory(downLimit,apiKey,apiSecret,destSheet){
   }
 
   var ss = SpreadsheetApp.getActive();
+  var currentSheet = ss.getSheetByName(destSheet);
+  currentSheet.clearContents();
   var header = [];
   header.push(["transactTime","transactType","amount","fee","address","transactStatus","walletBalance"]);
   var cell = ss.getSheetByName(destSheet).getRange(1,1,header.length, 7);


### PR DESCRIPTION
Sometimes there is an issue with the last row being left behind from the previous download when there is no unrealised profit row at the top. Clearing the PASTE sheet before pushing the new data seems to work better. 
Lines 136, 137